### PR TITLE
feat($translate): Add the possibility to use a field name key generator ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,41 @@ $translateProvider.translations('de', {
 });
 ```
 
+#### Custom field name translation keys
+By default the translation key for the field name is put together as ```Type.Fieldname```, but
+sometimes your translations might be a bit more complicated and you need more freedom when
+generating your field names translation key. For example you would like to use an article in
+another language to make it sound more natural.
+
+This can be achieved by defining a `valdrFieldNameKeyGenerator` function like this:
+
+```javascript
+module.factory('valdrFieldNameSuffix', function() {
+  return function(violation) {
+    return violation.type + '.' + violation.field + '.' + violation.validator + 'Name';
+  }
+});
+
+valdrProvider.addConstraints({
+  'Person': {
+    'lastName': {
+      'required': { 'message': 'message.required' }
+    }
+  }
+});
+
+$translateProvider.translations('en', {
+  'message.required': 'Please enter {{fieldName}}.',
+  'Person.lastName.requiredName' : 'the Last name'
+  }
+});
+
+$translateProvider.translations('de', {
+  'message.required': 'Bitte geben sie {{fieldName}} ein.',
+  'Person.lastName.requiredName': 'den Nachnamen'
+});
+```
+
 ### Show messages for AngularJS built-in validators
 To show messages for the AngularJS built-in validators like ```required``` and ```number``` the messages can be registered by validator name in the ```valdrMessageProvider```:
 

--- a/src/message/valdrMessage-directive.js
+++ b/src/message/valdrMessage-directive.js
@@ -75,8 +75,7 @@ angular.module('valdr')
           var updateTranslations = function () {
             if (valdrMessage.translateAvailable && angular.isArray(scope.violations)) {
               angular.forEach(scope.violations, function (violation) {
-                var fieldNameKey = violation.type + '.' + violation.field;
-                valdrMessage.$translate(fieldNameKey).then(function (translation) {
+                valdrMessage.$translate(valdrMessage.fieldNameKeyGenerator(violation)).then(function (translation) {
                   violation.fieldName = translation;
                 });
               });

--- a/src/message/valdrMessage-service.js
+++ b/src/message/valdrMessage-service.js
@@ -47,8 +47,19 @@ angular.module('valdr')
         }
       }
 
+      function getFieldNameKeyGenerator() {
+        try {
+          return $injector.get('valdrFieldNameKeyGenerator');
+        } catch (error) {
+          return function(violation) {
+            return violation.type + '.' + violation.field;
+          };
+        }
+      }
+
       var $translate = getTranslateService(),
-        translateAvailable = angular.isDefined($translate);
+        translateAvailable = angular.isDefined($translate),
+        fieldNameKeyGenerator = getFieldNameKeyGenerator();
 
       function determineTemplate() {
         if (angular.isDefined(userDefinedTemplate)) {
@@ -77,6 +88,7 @@ angular.module('valdr')
         },
         translateAvailable: translateAvailable,
         $translate: $translate,
+        fieldNameKeyGenerator: fieldNameKeyGenerator,
         addMessages: addMessages,
         getMessage: getMessage
       };


### PR DESCRIPTION
...in the translation

Add field name key generator to allow more complex translations for the field name to be used.
Sometimes translations are not as simple as just `type.fieldname` and therefore need a custom generator.
In some cases they might be 'type.fieldname.withArticle' or something similar to support more natural sounding translations.