### PR TITLE
$watch on the form field object not triggered correctly in the valdrMessage directive

### DIFF
--- a/src/message/valdrMessage-directive.js
+++ b/src/message/valdrMessage-directive.js
@@ -127,7 +127,7 @@ angular.module('valdr')
           if (scope.formField) {
             return {
               valdr: scope.formField.valdrViolations,
-              $error: scope.formField.$error
+              error: scope.formField.$error
             };
           }
         };


### PR DESCRIPTION
$watch on the form field object is not triggered correctly in the valdrMessage directive. The reason for that is the name of the property ('$error'). Because the 3rd argument of the $scope.$watch is set (equals = true), the angular.equals is triggered which ignores properties starting with '$'.
