### PR TITLE
fix(valdrFormItem): added check for valdrEnabled and replaced error with

### DIFF
--- a/src/core/valdrFormItem-directive.js
+++ b/src/core/valdrFormItem-directive.js
@@ -46,8 +46,8 @@ var valdrFormItemDirectiveDefinitionFactory = function (restrict) {
 
           valdrFormGroupController.addFormItem(ngModelController);
 
-          if (valdrUtil.isEmpty(fieldName)) {
-            throw new Error('Form element with ID "' + attrs.id + '" is not bound to a field name.');
+          if (valdrUtil.isEmpty(fieldName) && valdrEnabled.isEnabled()) {
+            console.warn('Form element with ID "' + attrs.id + '" is not bound to a field name.');
           }
 
           var updateNgModelController = function (validationResult) {

--- a/src/core/valdrFormItem-directive.spec.js
+++ b/src/core/valdrFormItem-directive.spec.js
@@ -165,8 +165,9 @@ describe('valdrFormItem directive', function () {
 
     runFormItemCommonTests();
 
-    it('should throw error if no field name is provided on the input', function () {
+    it('should log warning if no field name is provided on the input', function () {
       // given
+      spyOn(console, 'warn');
       var invalidInput =
         '<form name="demoForm">' +
           '<div valdr-type="TestClass">' +
@@ -174,10 +175,28 @@ describe('valdrFormItem directive', function () {
           '</div>' +
         '</form>';
 
-      // when / then
-      expect(function () {
-        $compile(angular.element(invalidInput))($scope);
-      }).toThrow(new Error('Form element with ID "undefined" is not bound to a field name.'));
+      // when
+      $compile(angular.element(invalidInput))($scope);
+
+      // then
+      expect(console.warn).toHaveBeenCalledWith('Form element with ID "undefined" is not bound to a field name.');
+    });
+
+    it('should NOT log warning if no field name is provided on the input but valdr is disabled', function () {
+      // given
+      spyOn(console, 'warn');
+      var invalidInput =
+        '<form name="demoForm" valdr-enabled="false">' +
+        '  <div valdr-type="TestClass">' +
+        '    <input type="text" ng-model="myObject.field">' +
+        '  </div>' +
+        '</form>';
+
+      // when
+      compileTemplate(invalidInput);
+
+      // then
+      expect(console.warn).not.toHaveBeenCalled();
     });
 
     it('should NOT use valdr validation if valdr-no-validate is set', function () {


### PR DESCRIPTION
Previously, an error was thrown when the name for some form element was not defined even if valdr was disabled using valdr-enabled directive. I added a check for valdr enabled and replaced the error with warning.