### PR TITLE
hibernateEmailValidator: also return 'true' for NaN input

### DIFF
--- a/src/core/validators/hibernateEmailValidator.js
+++ b/src/core/validators/hibernateEmailValidator.js
@@ -19,7 +19,7 @@ angular.module('valdr')
        * @returns {boolean} true if valid
        */
       validate: function (value) {
-        if (valdrUtil.isEmpty(value)) {
+        if (valdrUtil.isEmpty(value) || valdrUtil.isNaN(value)) {
           return true;
         }
 

--- a/src/core/validators/hibernateEmailValidator.spec.js
+++ b/src/core/validators/hibernateEmailValidator.spec.js
@@ -15,6 +15,7 @@ describe('valdrEmailValidator', function () {
   it('should return true for empty values', function () {
     expect(hibernateEmailValidator.validate('')).toBe(true);
     expect(hibernateEmailValidator.validate(undefined)).toBe(true);
+    expect(hibernateEmailValidator.validate(Number.NaN)).toBe(true);
   });
 
   it('should return true for valid email addresses', function () {


### PR DESCRIPTION
Ran into this in our project, where the input was NaN at some time.