### PR TITLE
Fixed potential memory leaks

### DIFF
--- a/src/core/valdrFormGroup-directive.js
+++ b/src/core/valdrFormGroup-directive.js
@@ -98,7 +98,10 @@ var valdrFormGroupDirectiveDefinition =
         };
 
         this.removeMessageElement = function (ngModelController) {
-          messageElements[ngModelController.$name].remove();
+          if (messageElements[ngModelController.$name]) {
+            messageElements[ngModelController.$name].remove();
+            delete messageElements[ngModelController.$name];
+          }
         };
 
       }]

--- a/src/message/valdrMessage-directive.js
+++ b/src/message/valdrMessage-directive.js
@@ -141,8 +141,12 @@ angular.module('valdr')
           }
         }, true);
 
-        $rootScope.$on('$translateChangeSuccess', function () {
+        var unregisterTranslateChangeHandler = $rootScope.$on('$translateChangeSuccess', function () {
           updateTranslations();
+        });
+
+        scope.$on('$destroy', function () {
+          unregisterTranslateChangeHandler();
         });
       }
     };

--- a/src/message/valdrMessage-directive.spec.js
+++ b/src/message/valdrMessage-directive.spec.js
@@ -342,6 +342,21 @@ describe('valdrMessage directive with angular-translate', function () {
     expect(element.find('span').html()).toBe('field: Field Name param: 3 secondParam: 4');
   });
 
+  it('should unregister translate change handler on destroy to avoid potential memory leaks', function () {
+    // given
+    var element = compileTemplate();
+    spyOn(valdrMessage, '$translate').andReturn({ then: function () {} });
+    $scope.$destroy();
+    element.remove();
+
+    // when
+    $translate.use('de');
+    $scope.$digest();
+
+    // then
+    expect(valdrMessage.$translate).not.toHaveBeenCalled();
+  });
+
 });
 
 describe('valdrMessage directive with angular-translate and valdrFieldNameKeyGenerator', function () {


### PR DESCRIPTION
## Description
### 1. valdrMessage-directive [major]
Cause: the directive registers event listener on the $rootScope which it is not unregistered when the directive is destroyed.
Consequence: The $rootScope retains reference to the directive scope and element through the event handler's function closure. The scope and the element have references to their parent and children, which means that large piece of $scope and DOM objects will remain in memory after their use because they are not eligible for garbage collection. This causes major memory leaks due to the fact that the $rootScope is singleton service and will be alive though out the whole application operation time.

### 2. valdrFormGroup-directive [minor]
Cause: valdrFormGroup controller retains reference to the valdrMessage elements for the former valdrFormItems.
Consequence: former valdrMessage elements cannot be garbage collected after their removal from the DOM. However this is not a major memory leak because it is temporary i.e. while the valdrFormGroup directive instance is alive.


