### PR TITLE
fix(sizeValidator):changes sizeValidator to accept numbers

### DIFF
--- a/src/core/validators/sizeValidator.js
+++ b/src/core/validators/sizeValidator.js
@@ -16,8 +16,9 @@ angular.module('valdr')
           maxLength = constraint.max;
 
         value = value || '';
-        return value.length >= minLength &&
-          (maxLength === undefined || value.length <= maxLength);
+        var stringValue = value.toString();
+        return stringValue.length >= minLength &&
+          (maxLength === undefined || stringValue.length <= maxLength);
       }
     };
   });

--- a/src/core/validators/sizeValidator.spec.js
+++ b/src/core/validators/sizeValidator.spec.js
@@ -60,4 +60,15 @@ describe('valdrSizeValidator', function () {
     expect(valid).toBe(false);
   });
 
+  it('should be valid if input is a number', function () {
+    // given
+    constraint.min = 1;
+
+    // when
+    var valid = sizeValidator.validate(123, constraint);
+
+    // then
+    expect(valid).toBe(true);
+  });
+
 });


### PR DESCRIPTION
We're using valdr in our project, and I came across the bug that is described in issue #59, where an input field with `type="number"` is always in error. This PR solves it by converting the input value in `sizeValidator` to a string before checking the length.