### PR TITLE
min length validator and size validator validate only length

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "load-grunt-tasks": "~2.0.0",
     "express": "~3.4.8",
-    "grunt-express": "~1.2.1"
+    "grunt-express": "~1.2.1",
+    "grunt-parallel": "^0.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "grunt-contrib-watch": "~0.6.1",
     "load-grunt-tasks": "~2.0.0",
     "express": "~3.4.8",
-    "grunt-express": "~1.2.1",
-    "grunt-parallel": "^0.4.1"
+    "grunt-express": "~1.2.1"
   }
 }

--- a/src/core/valdr-service.spec.js
+++ b/src/core/valdr-service.spec.js
@@ -195,10 +195,7 @@ describe('valdr', function () {
       expect(sizeValidator.validate).toHaveBeenCalled();
       expect(requiredValidator.validate).toHaveBeenCalled();
       expect(validationResult.valid).toBe(false);
-      expect(validationResult.violations[0].field).toBe('firstName');
-      expect(validationResult.violations[0].value).toBeUndefined();
-      expect(validationResult.violations[0].message).toBe('size');
-      expect(validationResult.violations[1].message).toBe('required');
+      expect(validationResult.violations[0].message).toBe('required');
     });
 
   });

--- a/src/core/validators/minLengthValidator.js
+++ b/src/core/validators/minLengthValidator.js
@@ -15,7 +15,7 @@ angular.module('valdr')
         var minLength = constraint.number;
 
         if (valdrUtil.isEmpty(value)) {
-          return minLength === 0;
+          return true;
         }
 
         if (typeof value === 'string') {

--- a/src/core/validators/minLengthValidator.spec.js
+++ b/src/core/validators/minLengthValidator.spec.js
@@ -70,7 +70,7 @@ describe('valdrMinLengthValidator', function () {
     expect(valid).toBe(true);
   });
 
-  it('should be invalid if minLength is 1 and value undefined', function () {
+  it('should be valid if minLength is 1 and value undefined', function () {
     // given
     constraint.number = 1;
 
@@ -78,10 +78,10 @@ describe('valdrMinLengthValidator', function () {
     var valid = minLengthValidator.validate(undefined, constraint);
 
     // then
-    expect(valid).toBe(false);
+    expect(valid).toBe(true);
   });
 
-  it('should be invalid if minLength is 1 and value null', function () {
+  it('should be valid if minLength is 1 and value null', function () {
     // given
     constraint.number = 1;
 
@@ -89,7 +89,7 @@ describe('valdrMinLengthValidator', function () {
     var valid = minLengthValidator.validate(null, constraint);
 
     // then
-    expect(valid).toBe(false);
+    expect(valid).toBe(true);
   });
 
 });

--- a/src/core/validators/sizeValidator.js
+++ b/src/core/validators/sizeValidator.js
@@ -1,6 +1,6 @@
 angular.module('valdr')
 
-  .factory('valdrSizeValidator', function () {
+  .factory('valdrSizeValidator', ['valdrUtil', function (valdrUtil) {
     return {
       name: 'size',
 
@@ -16,8 +16,13 @@ angular.module('valdr')
           maxLength = constraint.max;
 
         value = value || '';
+
+        if (valdrUtil.isEmpty(value)) {
+          return true;
+        }
+
         return value.length >= minLength &&
           (maxLength === undefined || value.length <= maxLength);
       }
     };
-  });
+  }]);

--- a/src/core/validators/sizeValidator.spec.js
+++ b/src/core/validators/sizeValidator.spec.js
@@ -49,7 +49,7 @@ describe('valdrSizeValidator', function () {
     expect(valid).toBe(true);
   });
 
-  it('should be invalid if min is 1 and value undefined', function () {
+  it('should be valid if min is 1 and value undefined', function () {
     // given
     constraint.min = 1;
 
@@ -57,7 +57,7 @@ describe('valdrSizeValidator', function () {
     var valid = sizeValidator.validate(undefined, constraint);
 
     // then
-    expect(valid).toBe(false);
+    expect(valid).toBe(true);
   });
 
 });


### PR DESCRIPTION
When size or minlength validator are applied to some fields, they became required even if the required validator is not applied, as described into [issue #99](https://github.com/netceteragroup/valdr/issues/99).

This pull request changes this behavior, minlength and size validators don't invalidate the field if it is empty