### PR TITLE
fix(valdr-message): handle $translate promise rejection (in Angular 1…

### DIFF
--- a/src/message/valdrMessage-directive.js
+++ b/src/message/valdrMessage-directive.js
@@ -80,9 +80,11 @@ angular.module('valdr')
         var updateTranslations = function () {
           if (valdrMessage.translateAvailable && angular.isArray(scope.violations)) {
             angular.forEach(scope.violations, function (violation) {
-              valdrMessage.$translate(valdrMessage.fieldNameKeyGenerator(violation)).then(function (translation) {
-                violation.fieldName = translation;
-              });
+              valdrMessage.$translate(valdrMessage.fieldNameKeyGenerator(violation))
+                .then(function (translation) {
+                  violation.fieldName = translation;
+                })
+                .catch(angular.noop);
             });
           }
         };


### PR DESCRIPTION
….6+ ALL promise rejections should be handled)

Since Angular 1.6+, all possible promise rejections should be handled, otherwise a "Possible unhandled rejection..." error is thrown.

This feature is enabled by default: https://code.angularjs.org/1.6.4/docs/api/ng/provider/$qProvider